### PR TITLE
test(utils): add unit tests for scoring and array utils

### DIFF
--- a/src/utils/array.utils.test.ts
+++ b/src/utils/array.utils.test.ts
@@ -1,0 +1,62 @@
+import { shuffle } from './array.utils';
+
+describe('shuffle', () => {
+  it('returns an array of the same length', () => {
+    expect(shuffle([1, 2, 3, 4, 5])).toHaveLength(5);
+  });
+
+  it('returns an empty array unchanged', () => {
+    expect(shuffle([])).toEqual([]);
+  });
+
+  it('returns a single-element array unchanged', () => {
+    expect(shuffle([42])).toEqual([42]);
+  });
+
+  it('contains exactly the original elements (no additions or removals)', () => {
+    const input = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const result = shuffle([...input]);
+    expect(result.sort((a, b) => a - b)).toEqual(input);
+  });
+
+  it('works with string arrays', () => {
+    const input = ['a', 'b', 'c', 'd'];
+    const result = shuffle([...input]);
+    expect(result).toHaveLength(4);
+    expect([...result].sort()).toEqual([...input].sort());
+  });
+
+  it('works with object arrays (preserves references)', () => {
+    const obj1 = { id: 1 };
+    const obj2 = { id: 2 };
+    const obj3 = { id: 3 };
+    const result = shuffle([obj1, obj2, obj3]);
+    expect(result).toContain(obj1);
+    expect(result).toContain(obj2);
+    expect(result).toContain(obj3);
+  });
+
+  it('mutates the array in place and returns the same reference', () => {
+    const input = [1, 2, 3, 4, 5];
+    const result = shuffle(input);
+    expect(result).toBe(input);
+  });
+
+  it('produces varied orderings across multiple runs (statistical check)', () => {
+    // With 10 elements, the probability of getting the same permutation twice
+    // in a row is 1/10! ≈ 2.76e-7. Ten identical runs is effectively impossible.
+    const original = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const seenOrders = new Set<string>();
+    for (let i = 0; i < 10; i++) {
+      seenOrders.add(shuffle([...original]).join(','));
+    }
+    expect(seenOrders.size).toBeGreaterThan(1);
+  });
+
+  it('handles arrays with duplicate values (does not deduplicate)', () => {
+    const input = [1, 1, 2, 2, 3];
+    const result = shuffle([...input]);
+    expect(result).toHaveLength(5);
+    expect(result.sort((a, b) => a - b)).toEqual([1, 1, 2, 2, 3]);
+  });
+});

--- a/src/utils/scoring.utils.test.ts
+++ b/src/utils/scoring.utils.test.ts
@@ -1,0 +1,153 @@
+import { scoreAdjective, getPercentilesFromAverages } from './scoring.utils';
+
+// ─── scoreAdjective ───────────────────────────────────────────────────────────
+
+describe('scoreAdjective', () => {
+  it('returns veryLow for scores below 10', () => {
+    expect(scoreAdjective(0)).toBe('veryLow');
+    expect(scoreAdjective(9)).toBe('veryLow');
+  });
+
+  it('returns low for scores 10–24', () => {
+    expect(scoreAdjective(10)).toBe('low');
+    expect(scoreAdjective(24)).toBe('low');
+  });
+
+  it('returns modLow for scores 25–39', () => {
+    expect(scoreAdjective(25)).toBe('modLow');
+    expect(scoreAdjective(39)).toBe('modLow');
+  });
+
+  it('returns average for scores 40–59', () => {
+    expect(scoreAdjective(40)).toBe('average');
+    expect(scoreAdjective(50)).toBe('average');
+    expect(scoreAdjective(59)).toBe('average');
+  });
+
+  it('returns modHigh for scores 60–74', () => {
+    expect(scoreAdjective(60)).toBe('modHigh');
+    expect(scoreAdjective(74)).toBe('modHigh');
+  });
+
+  it('returns high for scores 75–89', () => {
+    expect(scoreAdjective(75)).toBe('high');
+    expect(scoreAdjective(89)).toBe('high');
+  });
+
+  it('returns veryHigh for scores 90 and above', () => {
+    expect(scoreAdjective(90)).toBe('veryHigh');
+    expect(scoreAdjective(99)).toBe('veryHigh');
+    expect(scoreAdjective(100)).toBe('veryHigh');
+  });
+
+  it('respects >= boundary semantics at every threshold', () => {
+    // Each boundary value must land in the higher bucket, not the lower
+    expect(scoreAdjective(10)).toBe('low');      // NOT veryLow
+    expect(scoreAdjective(25)).toBe('modLow');   // NOT low
+    expect(scoreAdjective(40)).toBe('average');  // NOT modLow
+    expect(scoreAdjective(60)).toBe('modHigh');  // NOT average
+    expect(scoreAdjective(75)).toBe('high');     // NOT modHigh
+    expect(scoreAdjective(90)).toBe('veryHigh'); // NOT high
+  });
+});
+
+// ─── getPercentilesFromAverages ───────────────────────────────────────────────
+
+describe('getPercentilesFromAverages', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('returns 50 when score equals the male group mean (Openness)', () => {
+    sessionStorage.setItem('gender', 'male');
+    // Male Openness: mean=3.6, stdDev=0.51 → z=0 → 50th percentile
+    const averages: Map<string, [number, number]> = new Map([
+      ['Openness', [1, 3.6]],
+    ]);
+    expect(getPercentilesFromAverages(averages)['Openness']).toBe(50);
+  });
+
+  it('returns 50 when score equals the female group mean (Openness)', () => {
+    sessionStorage.setItem('gender', 'female');
+    // Female Openness: mean=3.61, stdDev=0.52 → z=0 → 50th percentile
+    const averages: Map<string, [number, number]> = new Map([
+      ['Openness', [1, 3.61]],
+    ]);
+    expect(getPercentilesFromAverages(averages)['Openness']).toBe(50);
+  });
+
+  it('returns ~84 for a score 1 stdDev above the male mean', () => {
+    sessionStorage.setItem('gender', 'male');
+    // Male Openness: mean=3.6, stdDev=0.51 → score=4.11 → z=1 → ~84th pct
+    const averages: Map<string, [number, number]> = new Map([
+      ['Openness', [1, 4.11]],
+    ]);
+    expect(getPercentilesFromAverages(averages)['Openness']).toBe(84);
+  });
+
+  it('returns ~16 for a score 1 stdDev below the male mean', () => {
+    sessionStorage.setItem('gender', 'male');
+    // Male Openness: mean=3.6, stdDev=0.51 → score=3.09 → z=-1 → ~16th pct
+    const averages: Map<string, [number, number]> = new Map([
+      ['Openness', [1, 3.09]],
+    ]);
+    expect(getPercentilesFromAverages(averages)['Openness']).toBe(16);
+  });
+
+  it('clamps extreme high scores to 99', () => {
+    sessionStorage.setItem('gender', 'male');
+    const averages: Map<string, [number, number]> = new Map([
+      ['Openness', [1, 99.0]], // far above mean
+    ]);
+    expect(getPercentilesFromAverages(averages)['Openness']).toBe(99);
+  });
+
+  it('clamps extreme low scores to 1', () => {
+    sessionStorage.setItem('gender', 'male');
+    const averages: Map<string, [number, number]> = new Map([
+      ['Openness', [1, -99.0]], // far below mean
+    ]);
+    expect(getPercentilesFromAverages(averages)['Openness']).toBe(1);
+  });
+
+  it('handles multiple traits in a single call', () => {
+    sessionStorage.setItem('gender', 'male');
+    // Male Openness mean=3.6, Male Extraversion mean=3.37 → both at mean → both 50
+    const averages: Map<string, [number, number]> = new Map([
+      ['Openness', [1, 3.6]],
+      ['Extraversion', [1, 3.37]],
+    ]);
+    const result = getPercentilesFromAverages(averages);
+    expect(result['Openness']).toBe(50);
+    expect(result['Extraversion']).toBe(50);
+  });
+
+  it('returns an empty object for an empty averages map', () => {
+    sessionStorage.setItem('gender', 'male');
+    expect(getPercentilesFromAverages(new Map())).toEqual({});
+  });
+
+  it('throws when an unknown key is passed', () => {
+    sessionStorage.setItem('gender', 'male');
+    const averages: Map<string, [number, number]> = new Map([
+      ['NonExistentTrait', [1, 3.5]],
+    ]);
+    expect(() => getPercentilesFromAverages(averages)).toThrow(
+      'Mean or std dev not found in data map for key: NonExistentTrait',
+    );
+  });
+
+  it('all output percentiles are between 1 and 99 inclusive', () => {
+    sessionStorage.setItem('gender', 'female');
+    const averages: Map<string, [number, number]> = new Map([
+      ['Openness', [1, 1.0]],
+      ['Conscientiousness', [1, 5.0]],
+      ['Extraversion', [1, 3.42]],
+    ]);
+    const result = getPercentilesFromAverages(averages);
+    for (const val of Object.values(result)) {
+      expect(val).toBeGreaterThanOrEqual(1);
+      expect(val).toBeLessThanOrEqual(99);
+    }
+  });
+});


### PR DESCRIPTION
## Category
Tests

## What changed
- Added `src/utils/scoring.utils.test.ts` — 17 tests covering `scoreAdjective` and `getPercentilesFromAverages`
- Added `src/utils/array.utils.test.ts` — 8 tests covering `shuffle`

## Why it matters
The test suite was nearly empty. These tests lock in the behaviour of the three utility files introduced in PR #12 and catch real-bug classes:

- **`scoreAdjective`** — boundary-value tests confirm the `>=` semantics at every threshold (e.g. 10 → `low`, not `veryLow`)
- **`getPercentilesFromAverages`** — known-value tests verify z-score math (mean → 50th pct, ±1 stdDev → 84th/16th pct), clamping to [1, 99], gender branching (male vs female data maps), error on unknown key, and empty-map edge case
- **`shuffle`** — confirms same-length output, in-place mutation (same reference), no element loss or duplication, handles duplicates and objects, and a statistical check that randomness is actually exercised

## Checklist
- [x] One theme: tests only — no production code changed
- [x] Both new test suites pass (`array.utils.test.ts`, `scoring.utils.test.ts`)
- [x] Build failure (`aws-exports` not found) is pre-existing on `master` and unrelated to this PR

## Next Suggestion
Fix the pre-existing `aws-exports` build error (likely needs an `aws-exports.js` stub or Amplify environment variable) and address the ordinal-suffix bug in `buildAIContext` (`82th` → `82nd`) caught by the existing `interpretations.utils.test.ts`.